### PR TITLE
Add shell viewer prototype

### DIFF
--- a/cmd/uhoh/examples/shell_viewer/main.go
+++ b/cmd/uhoh/examples/shell_viewer/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"runtime"
+
+	"github.com/go-go-golems/uhoh/pkg/wizard"
+	"github.com/go-go-golems/uhoh/pkg/wizard/shellcmd"
+)
+
+func main() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("unable to determine caller info")
+	}
+
+	wizardPath := filepath.Join(filepath.Dir(thisFile), "..", "wizard", "shell_viewer.yaml")
+	w, err := wizard.LoadWizard(
+		wizardPath,
+		wizard.WithActionCallback("runShell", runShellAction),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := w.Run(context.Background(), map[string]interface{}{}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runShellAction(ctx context.Context, _ map[string]interface{}, args map[string]interface{}) (interface{}, error) {
+	cmd, _ := args["cmd"].(string)
+	if cmd == "" {
+		return nil, fmt.Errorf("missing cmd argument")
+	}
+
+	return shellcmd.RunActionCallback(ctx, cmd, shellcmd.Options{
+		Title:    "Shell Viewer Demo",
+		KeepOpen: true,
+	})
+}

--- a/cmd/uhoh/examples/wizard/shell_viewer.yaml
+++ b/cmd/uhoh/examples/wizard/shell_viewer.yaml
@@ -1,0 +1,22 @@
+name: shell-viewer-test
+theme: Charm
+steps:
+  - id: run_shell
+    type: action
+    title: Run Echo
+    description: Execute a short echo command
+    action_type: function
+    function_name: runShell
+    show_progress: false
+    show_completion: false
+    arguments:
+      cmd: |
+        for i in $(seq 1 40); do
+          echo "stdout line $i"
+          sleep 0.05
+        done
+        for i in $(seq 1 10); do
+          echo "stderr line $i" >&2
+          sleep 0.05
+        done
+        printf 'final stdout line\n'

--- a/pkg/wizard/shellcmd/run.go
+++ b/pkg/wizard/shellcmd/run.go
@@ -1,0 +1,32 @@
+package shellcmd
+
+import (
+	"context"
+
+	"github.com/go-go-golems/uhoh/pkg/wizard/steps"
+)
+
+// RunActionCallback executes the shell viewer and returns an ActionCallbackResult suitable for
+// wiring into wizard action steps. The returned result marks UIHandled so the step can skip its
+// default completion notes. The Data payload is the underlying *Result.
+func RunActionCallback(ctx context.Context, cmdStr string, opts Options) (interface{}, error) {
+	res, err := Run(ctx, cmdStr, opts)
+	if res == nil {
+		return res, err
+	}
+
+	callbackResult := steps.ActionCallbackResult{
+		Data:      res,
+		UIHandled: true,
+	}
+
+	if err != nil {
+		return callbackResult, err
+	}
+
+	if res.Err != nil {
+		return callbackResult, res.Err
+	}
+
+	return callbackResult, nil
+}

--- a/pkg/wizard/shellcmd/viewer.go
+++ b/pkg/wizard/shellcmd/viewer.go
@@ -1,0 +1,450 @@
+package shellcmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type streamKind int
+
+const (
+	streamStdout streamKind = iota
+	streamStderr
+)
+
+type status int
+
+const (
+	statusInit status = iota
+	statusRunning
+	statusSucceeded
+	statusFailed
+)
+
+// Options configures the shell viewer behaviour.
+type Options struct {
+	WorkDir    string
+	Env        []string
+	Title      string
+	KeepOpen   bool
+	ProgramOps []tea.ProgramOption
+}
+
+// Result captures the outcome of a shell command run via the viewer.
+type Result struct {
+	Cmd       string
+	ExitCode  int
+	Output    string
+	Duration  time.Duration
+	Err       error
+	StartedAt time.Time
+	EndedAt   time.Time
+}
+
+type appendOutputMsg struct {
+	stream streamKind
+	text   string
+}
+
+type streamClosedMsg struct {
+	stream streamKind
+}
+
+type streamErrMsg struct {
+	stream streamKind
+	err    error
+}
+
+type commandFinishedMsg struct {
+	exitCode int
+	err      error
+}
+
+type commandStartFailedMsg struct {
+	err error
+}
+
+type tickMsg struct{}
+
+// Run launches the Bubble Tea viewer and blocks until the command completes or the program exits.
+func Run(ctx context.Context, cmdStr string, opts Options) (*Result, error) {
+	m := newModel(ctx, cmdStr, opts)
+	programOpts := []tea.ProgramOption{tea.WithAltScreen()}
+	if ctx != nil {
+		programOpts = append(programOpts, tea.WithContext(ctx))
+	}
+	if len(opts.ProgramOps) > 0 {
+		programOpts = append(programOpts, opts.ProgramOps...)
+	}
+
+	p := tea.NewProgram(m, programOpts...)
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	vm, ok := finalModel.(*model)
+	if !ok {
+		return nil, fmt.Errorf("unexpected final model type %T", finalModel)
+	}
+
+	res := &Result{
+		Cmd:       cmdStr,
+		ExitCode:  vm.exitCode,
+		Output:    vm.plainBuffer.String(),
+		Duration:  vm.endedAt.Sub(vm.startedAt),
+		Err:       vm.err,
+		StartedAt: vm.startedAt,
+		EndedAt:   vm.endedAt,
+	}
+
+	if vm.status == statusSucceeded {
+		res.Err = nil
+	} else if vm.err == nil && vm.exitCode != 0 {
+		res.Err = fmt.Errorf("command exited with code %d", vm.exitCode)
+	}
+
+	return res, nil
+}
+
+type model struct {
+	ctx    context.Context
+	cmdStr string
+	opts   Options
+	cmd    *exec.Cmd
+
+	stdoutReader *bufio.Reader
+	stderrReader *bufio.Reader
+
+	viewport viewport.Model
+	spinner  spinner.Model
+
+	status status
+
+	startedAt time.Time
+	endedAt   time.Time
+
+	exitCode int
+	err      error
+
+	stdoutClosed bool
+	stderrClosed bool
+
+	plainBuffer strings.Builder
+	styledBuf   strings.Builder
+
+	mu sync.Mutex
+
+	keepOpen bool
+	title    string
+}
+
+func newModel(ctx context.Context, cmdStr string, opts Options) *model {
+	vp := viewport.New(0, 0)
+	vp.SetContent("")
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+
+	return &model{
+		ctx:      ctx,
+		cmdStr:   cmdStr,
+		opts:     opts,
+		viewport: vp,
+		spinner:  sp,
+		status:   statusInit,
+		keepOpen: opts.KeepOpen,
+		title:    opts.Title,
+	}
+}
+
+func (m *model) Init() tea.Cmd {
+	if err := m.startCommand(); err != nil {
+		return func() tea.Msg {
+			return commandStartFailedMsg{err: err}
+		}
+	}
+
+	cmds := []tea.Cmd{m.spinner.Tick}
+	cmds = append(cmds, m.readStdoutCmd(), m.readStderrCmd(), m.waitCmd(), m.tickCmd())
+	return tea.Batch(cmds...)
+}
+
+func (m *model) startCommand() error {
+	m.status = statusRunning
+	m.startedAt = time.Now()
+
+	cmd := exec.CommandContext(m.ctx, "bash", "-lc", m.cmdStr)
+	if m.opts.WorkDir != "" {
+		cmd.Dir = m.opts.WorkDir
+	}
+	if len(m.opts.Env) > 0 {
+		cmd.Env = append(os.Environ(), m.opts.Env...)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	m.cmd = cmd
+	m.stdoutReader = bufio.NewReader(stdout)
+	m.stderrReader = bufio.NewReader(stderr)
+	return nil
+}
+
+func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case commandStartFailedMsg:
+		m.status = statusFailed
+		m.err = msg.err
+		m.exitCode = exitStatusFromError(msg.err)
+		m.endedAt = time.Now()
+		return m, tea.Quit
+
+	case appendOutputMsg:
+		m.appendOutput(msg)
+		switch msg.stream {
+		case streamStdout:
+			if m.stdoutReader != nil {
+				return m, m.readStdoutCmd()
+			}
+		case streamStderr:
+			if m.stderrReader != nil {
+				return m, m.readStderrCmd()
+			}
+		}
+		return m, nil
+
+	case streamClosedMsg:
+		if msg.stream == streamStdout {
+			m.stdoutReader = nil
+			m.stdoutClosed = true
+		} else {
+			m.stderrReader = nil
+			m.stderrClosed = true
+		}
+		return m, nil
+
+	case streamErrMsg:
+		if msg.err != nil && !errors.Is(msg.err, io.EOF) && m.err == nil {
+			m.err = msg.err
+		}
+		switch msg.stream {
+		case streamStdout:
+			return m, m.readStdoutCmd()
+		case streamStderr:
+			return m, m.readStderrCmd()
+		}
+		return m, nil
+
+	case commandFinishedMsg:
+		m.exitCode = msg.exitCode
+		if msg.err != nil {
+			m.err = msg.err
+		}
+		if msg.err == nil && msg.exitCode == 0 {
+			m.status = statusSucceeded
+		} else {
+			m.status = statusFailed
+		}
+		m.endedAt = time.Now()
+		if !m.keepOpen {
+			return m, tea.Quit
+		}
+		return m, nil
+
+	case tickMsg:
+		if m.status == statusRunning {
+			return m, m.tickCmd()
+		}
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		width := msg.Width
+		height := msg.Height
+		if height < 5 {
+			height = 5
+		}
+		m.viewport.Width = width
+		m.viewport.Height = height - 4
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.status == statusRunning {
+			switch msg.String() {
+			case "ctrl+c":
+				if m.cmd != nil && m.cmd.Process != nil {
+					_ = m.cmd.Process.Signal(os.Interrupt)
+				}
+				return m, nil
+			}
+		} else {
+			switch msg.String() {
+			case "q", "enter", "esc", "ctrl+c":
+				return m, tea.Quit
+			}
+		}
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.status == statusRunning {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m *model) readStdoutCmd() tea.Cmd {
+	if m.stdoutReader == nil {
+		return nil
+	}
+	reader := m.stdoutReader
+	return func() tea.Msg {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			return appendOutputMsg{stream: streamStdout, text: line}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return streamClosedMsg{stream: streamStdout}
+			}
+			return streamErrMsg{stream: streamStdout, err: err}
+		}
+		return streamClosedMsg{stream: streamStdout}
+	}
+}
+
+func (m *model) readStderrCmd() tea.Cmd {
+	if m.stderrReader == nil {
+		return nil
+	}
+	reader := m.stderrReader
+	return func() tea.Msg {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			return appendOutputMsg{stream: streamStderr, text: line}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return streamClosedMsg{stream: streamStderr}
+			}
+			return streamErrMsg{stream: streamStderr, err: err}
+		}
+		return streamClosedMsg{stream: streamStderr}
+	}
+}
+
+func (m *model) waitCmd() tea.Cmd {
+	if m.cmd == nil {
+		return nil
+	}
+	cmd := m.cmd
+	return func() tea.Msg {
+		err := cmd.Wait()
+		return commandFinishedMsg{
+			exitCode: exitStatusFromError(err),
+			err:      err,
+		}
+	}
+}
+
+func (m *model) tickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return tickMsg{} })
+}
+
+func (m *model) View() string {
+	headerTitle := m.title
+	if headerTitle == "" {
+		headerTitle = fmt.Sprintf("Running: %s", m.cmdStr)
+	}
+	header := lipgloss.NewStyle().Bold(true).Render(headerTitle)
+
+	statusLine := m.renderStatusLine()
+	body := m.viewport.View()
+
+	footer := m.renderFooter()
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, statusLine, body, footer)
+}
+
+func (m *model) appendOutput(msg appendOutputMsg) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.plainBuffer.WriteString(msg.text)
+
+	var styledText string
+	switch msg.stream {
+	case streamStdout:
+		styledText = msg.text
+	case streamStderr:
+		styledText = lipgloss.NewStyle().Foreground(lipgloss.Color("204")).Render(msg.text)
+	}
+
+	m.styledBuf.WriteString(styledText)
+	m.viewport.SetContent(m.styledBuf.String())
+	m.viewport.GotoBottom()
+}
+
+func (m *model) renderStatusLine() string {
+	elapsed := time.Since(m.startedAt)
+	switch m.status {
+	case statusInit:
+		return lipgloss.NewStyle().Render("Preparing command…")
+	case statusRunning:
+		return lipgloss.NewStyle().Render(fmt.Sprintf("%s  elapsed: %s", m.spinner.View(), elapsed.Truncate(time.Second)))
+	case statusSucceeded:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render(fmt.Sprintf("✔ completed in %s", m.endedAt.Sub(m.startedAt).Truncate(time.Millisecond)))
+	case statusFailed:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(fmt.Sprintf("✖ failed (exit %d) in %s", m.exitCode, m.endedAt.Sub(m.startedAt).Truncate(time.Millisecond)))
+	}
+	return ""
+}
+
+func (m *model) renderFooter() string {
+	switch m.status {
+	case statusInit, statusRunning:
+		return "Press Ctrl+C to interrupt."
+	case statusSucceeded, statusFailed:
+		return "Press q or Enter to close."
+	}
+	return ""
+}
+
+func exitStatusFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if status, ok := exitErr.Sys().(interface{ ExitStatus() int }); ok {
+			return status.ExitStatus()
+		}
+	}
+	return 1
+}

--- a/pkg/wizard/wizard.go
+++ b/pkg/wizard/wizard.go
@@ -28,6 +28,10 @@ type WizardCallbackFunc func(ctx context.Context, state map[string]interface{}) 
 // It returns a result that can be stored in the action's output key.
 type ActionCallbackFunc func(ctx context.Context, state map[string]interface{}, args map[string]interface{}) (interface{}, error)
 
+// ActionCallbackResult can be returned by ActionCallbackFunc implementations to provide structured
+// data and indicate that UI was handled outside of the default ActionStep notes.
+type ActionCallbackResult = steps.ActionCallbackResult
+
 // Wizard defines the top-level structure for a multi-step wizard.
 type Wizard struct {
 	Name        string                 `yaml:"name"`

--- a/ttmp/2025-09-16/01-design-for-a-better-shell-output.md
+++ b/ttmp/2025-09-16/01-design-for-a-better-shell-output.md
@@ -1,0 +1,118 @@
+# Design: Bubble Tea Shell Output for Onboarding Wizard
+
+## Background & Current Behaviour
+
+The onboarding CLI (see `go-go-mento/go/cmd/onboarding/main.go`) registers a `runCmd` action callback that shells out via `runShell(...)`. The helper executes `bash -lc <cmd>`, captures stdout and stderr into buffers, and optionally tees them directly to the process’ stdout/stderr whenever the `--stream` flag is set. After completion, the callback writes the combined output to a timestamped log file and surfaces the exit code back to the wizard state.
+
+Action steps inside the wizard are driven by `uhoh/pkg/wizard/steps/action_step.go`. Each step spins up a `huh.NewNote()` in a goroutine (“Executing action…”) while the callback runs, then, once the callback exits, shows a second note for completion. No UI bridge exists between the callback logic and the Bubble Tea runtime that powers the wizard. As soon as a callback writes straight to stdout/stderr the `huh` TUI corrupts, because the buffers bypass Bubble Tea’s alt-screen rendering and interleave with the wizard view.
+
+The net effect today:
+
+- Shell commands run to completion, but interactive feedback requires `--stream`, which breaks the layout because the output is *not* rendered through a Bubble Tea model.
+- While the first `huh` note is active, the user sees a frozen “Please wait…” screen; the actual command output either appears underneath the TUI (if streaming) or only in the log file afterward.
+- There is no per-line progress feedback, no scroll buffer, and no way to abort long-running commands from inside the wizard.
+
+## Problem Statement
+
+We need to render command output (stdout + stderr) inside the wizard itself so users can monitor progress without blowing up the TUI. The design must:
+
+1. Stream output incrementally inside a Bubble Tea component.
+2. Preserve the log-file behaviour for later inspection.
+3. Handle exit codes and propagate them back to the wizard state.
+4. Fit within the existing uhoh wizard/action-step architecture without forking the framework.
+5. Leave room for future improvements (cancellation, status badges, etc.).
+
+## High-Level Approach
+
+Introduce a dedicated Bubble Tea model that is responsible for running a shell command and rendering its output. Instead of teeing to `os.Stdout`, the `runCmd` callback will synchronously run this model (via `tea.NewProgram`) and collect the result. The wizard remains in control: the action step calls the callback, the callback blocks until the shell viewer exits, and only then does execution continue.
+
+Key ideas:
+
+- **Encapsulated tea.Model** – Build a `commandViewerModel` struct that starts the process, streams stdout/stderr into an internal buffer, and renders a viewport + status line. Use Charm `viewport` and `spinner` bubbles for UX consistency with other Go Go Golems tooling.
+- **Message flow** – Spawn goroutines that read the command’s stdout/stderr pipes line-by-line (or chunk-by-chunk) and emit `appendOutputMsg` messages into the Tea loop. When the process terminates, send a `commandFinishedMsg` carrying the exit code and error (if any).
+- **Log persistence** – The model collects the entire transcript in-memory. After the Tea program exits, the callback still writes the log file exactly once using the aggregated buffer, preserving the existing filesystem contract.
+- **Config knobs** – Feed working directory, environment (future), and friendly title into the model. Optionally reuse the `--stream` flag to toggle entering the viewer automatically vs. headless execution + static summary.
+- **Compatibility with ActionStep** – Because the model is rendered through Bubble Tea, it coexists with `huh`’s runtime. We should suppress the temporary “Executing action…” note when using the new viewer to avoid flicker—see the integration section below.
+
+## Detailed Design
+
+### 1. Bubble Tea Model (`commandViewerModel`)
+
+State fields:
+
+- `cmdStr`, `workDir`, `startTime`
+- `buffer` (strings.Builder for log; maybe also a slice for viewport lines)
+- `viewport` bubble configured with adaptive width/height (update on `tea.WindowSizeMsg`)
+- `spinner` bubble for “running” state
+- `status` enum: running / completed / failed
+- `exitCode`, `err`
+
+Lifecycle:
+
+- `Init()` returns a `tea.Cmd` that spawns the subprocess and starts reading pipes.
+- Two reader goroutines use `bufio.Scanner` to pull stdout/stderr. Each chunk is wrapped in `appendOutputMsg` (containing the text and stream tag) and sent via a channel -> `tea.Cmd` using `tea.Printf` or custom aggregator.
+- On process completion, emit `commandFinishedMsg` with exit code, error, and combined transcript.
+- `Update` handles:
+  - `appendOutputMsg`: append to buffer, append to viewport (apply color/style per stream), scroll to bottom when auto-scroll enabled.
+  - `commandFinishedMsg`: stop spinner, freeze viewport, record exit code/error, and return `tea.Quit` if we auto-close on success.
+  - Keyboard shortcuts: `ctrl+c` sends kill signal (if we add cancellation), `q` quits after command is done, `pgup/pgdn` scroll viewport, etc.
+- `View` renders header (command + cwd + elapsed + status), viewport body, footer hints.
+
+### 2. Running the Model from `runCmd`
+
+Inside `runCmd` (currently lines `136-180`):
+
+1. Build the model with the resolved command + options.
+2. Run it: `program := tea.NewProgram(model, tea.WithAltScreen())` then `resultModel, err := program.Run()`.
+3. Extract the transcript + exit metadata from the returned model (expose an accessor or type-assert the final model).
+4. If the Tea program itself errors, treat as command failure and bubble up `err`.
+5. Persist the transcript to the log file (honouring custom path overrides).
+6. Return `{cmd, exit_code, log_file}` as before.
+
+This replaces `runShell` entirely; we can delete it or refactor it into utility pieces (e.g. `startCommandProcess` shared between the model and logger). The existing `--stream` flag becomes redundant; instead, consider:
+
+- `--no-viewer`: skip Bubble Tea and fall back to headless execution (for CI scripts).
+- `--keep-open`: keep viewer open after success until user presses a key.
+
+Those switches can be wired later; the default behaviour should launch the viewer.
+
+### 3. Adjusting `ActionStep` UX
+
+The dual-note pattern in `ActionStep.Execute` (`uhoh/pkg/wizard/steps/action_step.go:56-110`) conflicts with our dedicated viewer. Options:
+
+- Minimal change: have the callback signal that it fully handled UI. We could return a sentinel error (e.g., `ErrActionUIHandled`) or set a known key in the step result (`ui_handled: true`). The step checks this before showing the completion note.
+- Cleaner change (preferred): extend `ActionStep` with a `ShowStatusNotes` boolean defaulting to true. For the wizard YAML we set it to false on steps that call `runCmd`. Implementation: new field + guard around the note logic.
+
+Either approach keeps the scope inside the `uhoh` repo, but because `go-go-mento` drives the wizard we can start with the sentinel key (no YAML changes) and follow up with a formal option in uhoh if needed.
+
+### 4. Error Handling & Logging
+
+- If the command exits non-zero, mark status as failed, leave the viewer open with the exit code highlighted, and return an `error` from the callback (preserving current semantics).
+- Always write the log file, even when the Tea program errors, so we retain the partial transcript.
+- When the viewer is aborted (future feature), return a context cancellation error so the wizard can decide whether to retry or abort the flow.
+
+### 5. Testing & Validation Strategy
+
+- **Manual**: run the onboarding wizard locally and verify the viewer renders output for fast & slow commands, handles terminal resize, and preserves logs.
+- **Unit-ish**: factor the pipe-reading logic into pure functions and drive with fake readers (in `*_test.go`). Verify multi-stream ordering and that log file contents match appended messages.
+- **Regression**: ensure `--log-file` still works by pointing to a temp path and checking file contents.
+
+## Migration Steps
+
+1. Implement the `commandViewerModel` and supporting helpers under a new internal package (`go-go-mento/go/cmd/onboarding/internal/tea/shellviewer`, for example).
+2. Replace `runShell` usage in `runCmd` with the Bubble Tea program run. Remove the `teeToStdout` parameter/flag or repurpose as discussed.
+3. Update logging logic to operate on the viewer’s transcript.
+4. Teach `ActionStep` to skip the default notes when the callback reports `ui_handled` (temporary shim) or add a core feature in uhoh to configure note behaviour.
+5. Verify wizard YAML doesn’t require changes; if we add `ShowStatusNotes`, update relevant steps accordingly.
+6. Document the new viewer behaviour in onboarding docs / README.
+
+## Risks & Open Questions
+
+- **Concurrency with huh runtime** – Running a nested Tea program while a huh note goroutine is active might still clash. Suppressing the note is important; otherwise, we need to ensure the note’s program exits before launching ours (e.g., by not starting it when UI is handled externally).
+- **Terminal capabilities** – Some users might prefer plain logs (non-interactive). Provide an escape hatch to disable the viewer.
+- **Command cancellation** – Not part of initial scope, but design should leave hooks (store `*exec.Cmd` inside the model for `ctrl+c`).
+- **Log growth** – For very chatty commands the in-memory buffer might be large; consider streaming to file concurrently while keeping a bounded viewport buffer (e.g., last N lines) to avoid OOM.
+
+---
+
+This design keeps all user-visible rendering inside Bubble Tea, aligns with the `uhoh` philosophy of declarative TUIs, and confines changes to the onboarding command plus a small extension in `uhoh`’s action step plumbing.


### PR DESCRIPTION
This pull request introduces a prototype for a shell viewer 
integrated into the onboarding wizard. The key changes include:

- Implementation of a new Bubble Tea model to run shell commands
  and display their output within the wizard interface.
- Addition of a new action callback for running shell commands 
  that collects and displays stdout and stderr incrementally.
- Enhancement of the ActionStep to support UI handling by the 
  shell viewer, allowing for a seamless user experience.